### PR TITLE
fix install emmc failure

### DIFF
--- a/luci-app-amlogic/Makefile
+++ b/luci-app-amlogic/Makefile
@@ -26,7 +26,7 @@ LUCI_TITLE:=LuCI support for Amlogic, Allwinner and Rockchip related boxs
 LUCI_PKGARCH:=all
 LUCI_DEPENDS:= \
 	@(aarch64||arm) +luci +luci-lib-nixio +block-mount +blkid +parted \
-	+dosfstools +e2fsprogs +lsblk +pv +losetup +uuidgen
+	+dosfstools +e2fsprogs +lsblk +pv +losetup +uuidgen +bash +perl +fdisk
 
 define Package/$(PKG_NAME)/conffiles
 /etc/config/amlogic

--- a/luci-app-amlogic/luasrc/view/amlogic/other_install.htm
+++ b/luci-app-amlogic/luasrc/view/amlogic/other_install.htm
@@ -85,7 +85,7 @@
 			function(x,status)
 			{
 				if ( x && x.status == 200 ) {
-					if(status.rule_install_status=="1")
+					if(status.rule_install_status!="0")
 					{
 						btn.value = '<%:Install Failed%>';
 					}


### PR DESCRIPTION
1. 修复了当`{rule_install_status: 127}`时（bash未安装），web页提示OpenWrt安装成功
2. 补充了一些未声明的依赖

感谢o大的这个工具，终于把op写入了emmc，准备养老了：）