### PR TITLE
Check required files only

### DIFF
--- a/luci-app-amlogic/root/usr/sbin/openwrt-kernel
+++ b/luci-app-amlogic/root/usr/sbin/openwrt-kernel
@@ -248,15 +248,15 @@ update_kernel() {
     tar -xf ${P4_PATH}/boot-${kernel_name}.tar.gz -C /boot
 
     # Check if the file exists
-    local valid_files
+    local required_files
     if [[ "${PLATFORM}" == "qemu-aarch64" ]]; then
-        valid_files="vmlinuz-${kernel_name} initrd.img-${kernel_name} config-${kernel_name} System.map-${kernel_name}"
+        required_files="vmlinuz-${kernel_name} initrd.img-${kernel_name}"
         rm -f /boot/uInitrd*
     else
-        valid_files="vmlinuz-${kernel_name} uInitrd-${kernel_name} config-${kernel_name} System.map-${kernel_name}"
+        required_files="vmlinuz-${kernel_name} uInitrd-${kernel_name}"
         rm -f /boot/initrd.img*
     fi
-    for f in ${valid_files}; do [[ -f "/boot/${f}" ]] || restore_kernel; done
+    for f in ${required_files}; do [[ -f "/boot/${f}" ]] || restore_kernel; done
 
     # Check if the files are the same
     (


### PR DESCRIPTION
Sometimes, people who build the kernel don't provide 'config-*' or 'System.map-*' files