### PR TITLE
一些非下载场景下的curl 新增了 --max-timeout 10 的参数

### DIFF
--- a/luci-app-amlogic/root/usr/share/amlogic/amlogic_check_firmware.sh
+++ b/luci-app-amlogic/root/usr/share/amlogic/amlogic_check_firmware.sh
@@ -142,7 +142,7 @@ check_updated() {
                 firmware_tags_array+=("${firmware_tags_name}")
             fi
         done < <(
-            curl -fsSL \
+            curl -fsSL -m 10 \
                 https://github.com/${server_firmware_url}/releases?page=${i} |
                 grep -oE 'releases/tag/([^" ]+)'
         )
@@ -173,7 +173,7 @@ check_updated() {
 
     # Retrieve the HTML code of the tags list page
     html_code="$(
-        curl -fsSL \
+        curl -fsSL -m 10 \
             https://github.com/${server_firmware_url}/releases/expanded_assets/${firmware_releases_tag}
     )"
 

--- a/luci-app-amlogic/root/usr/share/amlogic/amlogic_check_kernel.sh
+++ b/luci-app-amlogic/root/usr/share/amlogic/amlogic_check_kernel.sh
@@ -142,7 +142,7 @@ check_kernel() {
 
     # Check the version on the server
     latest_version="$(
-        curl -fsSL \
+        curl -fsSL -m 10 \
             ${kernel_api}/releases/expanded_assets/kernel_${kernel_tag} |
             grep -oE "${main_line_version}.[0-9]+.tar.gz" | sed 's/.tar.gz//' |
             sort -urV | head -n 1

--- a/luci-app-amlogic/root/usr/share/amlogic/amlogic_check_plugin.sh
+++ b/luci-app-amlogic/root/usr/share/amlogic/amlogic_check_plugin.sh
@@ -102,7 +102,7 @@ tolog "02. Start querying plugin version..."
 
 # Get the latest version
 latest_version="$(
-    curl -fsSL \
+    curl -fsSL -m 10 \
         https://github.com/ophub/luci-app-amlogic/releases |
         grep -oE 'expanded_assets/[0-9]+.[0-9]+.[0-9]+(-[0-9]+)?' | sed 's|expanded_assets/||' |
         sort -urV | head -n 1

--- a/onekey-install.sh
+++ b/onekey-install.sh
@@ -38,7 +38,7 @@ query_version() {
 
     # Get the latest version
     latest_version="$(
-        curl -fsSL \
+        curl -fsSL -m 10 \
             https://github.com/ophub/luci-app-amlogic/releases |
             grep -oE 'expanded_assets/[0-9]+.[0-9]+.[0-9]+(-[0-9]+)?' | sed 's|expanded_assets/||' |
             sort -urV | head -n 1


### PR DESCRIPTION
有时候网络"抽风"，curl一直占着进程。。。。现在非下载场景下，把整体timeout设置成了10s，防止check进程占用时间过久。