### PR TITLE
Use busybox which to check dependencies (fix #54)

### DIFF
--- a/luci-app-amlogic/Makefile
+++ b/luci-app-amlogic/Makefile
@@ -26,7 +26,8 @@ LUCI_TITLE:=LuCI support for Amlogic, Allwinner and Rockchip related boxs
 LUCI_PKGARCH:=all
 LUCI_DEPENDS:= \
 	@(aarch64||arm) +luci +luci-lib-nixio +block-mount +blkid +parted +curl \
-	+dosfstools +e2fsprogs +jq +lsblk +pv +losetup +uuidgen +bash +perl +fdisk
+	+dosfstools +e2fsprogs +jq +lsblk +pv +losetup +uuidgen +bash +perl +fdisk \
+	+busybox
 
 define Package/$(PKG_NAME)/conffiles
 /etc/config/amlogic

--- a/luci-app-amlogic/root/usr/sbin/openwrt-kernel
+++ b/luci-app-amlogic/root/usr/sbin/openwrt-kernel
@@ -56,7 +56,7 @@ init_var() {
     [[ "${1}" == "yes" ]] && AUTO_MAINLINE_UBOOT="yes"
 
     # Check dependencies
-    [[ -n "$(which tar)" ]] || error_msg "Missing [ tar ] in OpenWrt firmware, unable to update kernel"
+    [[ -n "$(busybox which tar)" ]] || error_msg "Missing [ tar ] in OpenWrt firmware, unable to update kernel"
 
     # Check release file
     if [[ -s "${release_file}" ]]; then
@@ -148,7 +148,7 @@ check_kernel() {
     sha256sums_file="sha256sums"
     sha256sums_check="1"
     [[ -s "${sha256sums_file}" && -n "$(cat ${sha256sums_file})" ]] || sha256sums_check="0"
-    [[ -n "$(which sha256sum)" ]] || sha256sums_check="0"
+    [[ -n "$(busybox which sha256sum)" ]] || sha256sums_check="0"
     [[ "${sha256sums_check}" -eq "1" ]] && echo -e "Enable sha256sum checking..."
 
     # Loop check file

--- a/luci-app-amlogic/root/usr/sbin/openwrt-update-amlogic
+++ b/luci-app-amlogic/root/usr/sbin/openwrt-update-amlogic
@@ -117,7 +117,7 @@ fi
 DEPENDS="lsblk uuidgen grep awk btrfs mkfs.fat mkfs.btrfs md5sum fatlabel"
 echo "Check the necessary dependencies..."
 for dep in ${DEPENDS}; do
-    WITCH=$(which ${dep})
+    WITCH=$(busybox which ${dep})
     if [ "${WITCH}" == "" ]; then
         echo "Dependent command: ${dep} does not exist, upgrade cannot be performed, only flash through U disk/TF card!"
         exit 1

--- a/luci-app-amlogic/root/usr/sbin/openwrt-update-kvm
+++ b/luci-app-amlogic/root/usr/sbin/openwrt-update-kvm
@@ -23,7 +23,7 @@ WORK_DIR="${4}"
 DEPENDS="lsblk uuidgen grep awk btrfs mkfs.fat mkfs.btrfs md5sum fatlabel jq"
 echo "Check the necessary dependencies..."
 for dep in ${DEPENDS}; do
-    WITCH=$(which ${dep})
+    WITCH=$(busybox which ${dep})
     if [ "${WITCH}" == "" ]; then
         echo "Dependent command: ${dep} does not exist, upgrade cannot be performed!"
         exit 1


### PR DESCRIPTION
Avoid differences in dependency checking behaviour caused by different versions of which.