### PR TITLE
EMMC docker 路径修复

### DIFF
--- a/luci-app-amlogic/root/usr/sbin/openwrt-install-amlogic
+++ b/luci-app-amlogic/root/usr/sbin/openwrt-install-amlogic
@@ -599,10 +599,10 @@ EOF
 
         # change data_root value in /etc/config/dockerd
         if [[ -f "/etc/init.d/dockerman" ]] && [[ -f "/etc/config/dockerd" ]]; then
-            sed -i "s|option data_root.*|option data_root '/mnt/${EMMC_NAME}p4/docker/'|g" /etc/config/dockerd
+            sed -i "s|option data_root.*|option data_root '/mnt/${EMMC_NAME}p4/docker/'|g" etc/config/dockerd
         fi
-        rm -rf /opt/docker && ln -sf /mnt/${EMMC_NAME}p4/docker/ /opt/docker >/dev/null
-        rm -rf /usr/bin/AdGuardHome && ln -sf /mnt/${EMMC_NAME}p4/AdGuardHome /usr/bin/ >/dev/null
+        rm -rf opt/docker && ln -sf /mnt/${EMMC_NAME}p4/docker/ opt/docker >/dev/null
+        rm -rf usr/bin/AdGuardHome && ln -sf /mnt/${EMMC_NAME}p4/AdGuardHome usr/bin/ >/dev/null
 
         echo "Edit configuration file ..."
         #cd /mnt/${EMMC_NAME}p2/usr/bin/


### PR DESCRIPTION
```bash
600        # change data_root value in /etc/config/dockerd
601        if [[ -f "/etc/init.d/dockerman" ]] && [[ -f "/etc/config/dockerd" ]]; then
602            sed -i "s|option data_root.*|option data_root '/mnt/${EMMC_NAME}p4/docker/'|g" /etc/config/dockerd
603        fi
604        rm -rf /opt/docker && ln -sf /mnt/${EMMC_NAME}p4/docker/ /opt/docker >/dev/null
605        rm -rf /usr/bin/AdGuardHome && ln -sf /mnt/${EMMC_NAME}p4/AdGuardHome /usr/bin/ >/dev/null
```
这里按逻辑应该是修改 emmc 中的文件，但 `/etc/config/dockerd`，`/opt/docker`，`/usr/bin/AdGuardHome` 都是根目录也就是 U盘 下的文件造成刷机后 emmc 系统中的 docker 工作目录仍然指向 `/mnt/sda4/docker`，而 U盘 系统中的 docker 工作目录反而指向了 `/mnt/mmcblk2p4/docker`。